### PR TITLE
iter improvements

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,9 @@
 name: Test
 
 on:
-  push: null
+  push: 
+    branches:
+      - main
   pull_request: null
   schedule: 
     - cron: '0 12 * * *'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2023-02-28
-
+## [0.3.0] - 2023-03-01
 ### Added
-- Added `i` iter format
+- `i` gained implicit format `({})` when none is specified `{:i}`
+- `i` gained support for indexing single values without range `{:i1}`
+
+### Changed
+- **Breaking Change**: `i` uses `{}` instead of `{it}`
+
+## [0.2.0] - 2023-02-28
+### Added
+- `i` iter format
 
 ### Changed
 - **Breaking Change**: Improved naming of error enums and variants

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,9 @@ Fixed URLs in Cargo.toml
 ## [0.1.0] - 2023-02-27
 Initial release
 
-[unreleased]: https://github.com/ModProg/interpolator/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/ModProg/interpolator/v0.2.0
-[0.1.2]: https://github.com/ModProg/interpolator/v0.1.2
-[0.1.1]: https://github.com/ModProg/interpolator/v0.1.1
+[unreleased]: https://github.com/ModProg/interpolator/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/ModProg/interpolator/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/ModProg/interpolator/compare/v0.1.2...v0.2.0
+[0.1.2]: https://github.com/ModProg/interpolator/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/ModProg/interpolator/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/ModProg/interpolator/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interpolator"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 categories = ["template-engine", "value-formatting", "text-processing"]
 description = "runtime format strings, fully compatible with std's macros"

--- a/README.md
+++ b/README.md
@@ -51,15 +51,22 @@ The feature `iter` enables an additional format trait `i`, it allows to
 format a list of values with a format string and an optional join
 expression.
 
-The syntax is `{list:i(the format string, '{it}' is the array element)(the
-optional join)}`, an empty join can also be omitted `{list:i({it})}`. Should
-you need to use `)` inside your format string or join, you can add `#`
-similar to rust's [raw string](https://doc.rust-lang.org/reference/tokens.html#raw-string-literals).
+The syntax is `{list:i(the format string, '{}' is the array element)(the
+join)}`, an empty join can also be omitted `{list:i({})}`. If join is omitted
+the format string `{}` can be omitted as well `{list:i}`.
+
+Should you need to use `)` inside your format string or join, you can add `#`
+similar to rust's [raw string](https://doc.rust-lang.org/reference/tokens.html#raw-string-literals)
+(i.e. `#(({}))#`).
 
 It is also possible to only iterate a sub-slice specified through a range
-before the format string, i.e. `{list:i1..4({it})}`. For open ranges range
+before the format string, i.e. `{list:i1..4}`. For open ranges range
 bounds can also be omitted. To index from the end, you can use negative
 range bounds.
+
+It is also possible to index a single value by only specifying an `isize`
+`{list:i1}`.
+
 
 A `Formattable` implementing iter is created using `Formattable::iter`:
 
@@ -67,7 +74,7 @@ A `Formattable` implementing iter is created using `Formattable::iter`:
 // HashMap macro
 use collection_literals::hash;
 use interpolator::{format, Formattable};
-// Needs to be a slice of references so because `Formattable::display` expects a
+// Needs to be a slice of references because `Formattable::display` expects a
 // reference
 let items = [&"hello", &"hi", &"hey"].map(Formattable::display);
 let items = Formattable::iter(&items);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,17 +29,21 @@ The feature `iter` enables an additional format trait `i`, it allows to
 format a list of values with a format string and an optional join
 expression.
 
-The syntax is `{list:i(the format string, '{it}' is the array element)(the
-optional join)}`, an empty join can also be omitted `{list:i({it})}`.
+The syntax is `{list:i(the format string, '{}' is the array element)(the
+join)}`, an empty join can also be omitted `{list:i({})}`. If join is omitted
+the format string `{}` can be omitted as well `{list:i}`.
 
 Should you need to use `)` inside your format string or join, you can add `#`
 similar to rust's [raw string](https://doc.rust-lang.org/reference/tokens.html#raw-string-literals)
-(i.e. `#(({it}))#`).
+(i.e. `#(({}))#`).
 
 It is also possible to only iterate a sub-slice specified through a range
-before the format string, i.e. `{list:i1..4({it})}`. For open ranges range
+before the format string, i.e. `{list:i1..4}`. For open ranges range
 bounds can also be omitted. To index from the end, you can use negative
 range bounds.
+
+It is also possible to index a single value by only specifying an [`isize`]
+`{list:i1}`.
 
 A [`Formattable`] implementing iter is created using [`Formattable::iter`]:
 
@@ -47,11 +51,11 @@ A [`Formattable`] implementing iter is created using [`Formattable::iter`]:
 // HashMap macro
 use collection_literals::hash;
 use interpolator::{format, Formattable};
-// Needs to be a slice of references so because `Formattable::display` expects a
+// Needs to be a slice of references because `Formattable::display` expects a
 // reference
 let items = [&"hello", &"hi", &"hey"].map(Formattable::display);
 let items = Formattable::iter(&items);
-let format_str = "Greetings: {items:i..-1(`{it}`)(, )} and {items:i-1..(`{it}`)}";
+let format_str = "Greetings: {items:i..-1(`{}`)(, )} and `{items:i-1}`";
 assert_eq!(
     format(format_str, &hash!("items" => items))?,
     "Greetings: `hello`, `hi` and `hey`"


### PR DESCRIPTION
-`i` without format
-`i` with index
-`{it}` -> `{}`
